### PR TITLE
Fix document regarding docker image version

### DIFF
--- a/dist/src/docker/README.md
+++ b/dist/src/docker/README.md
@@ -11,10 +11,10 @@ This image of a minimal AuthzForce Server runtime is intended to work together w
 
 This image gives you a minimal installation for testing purposes. The AuthzForce Installation and Administration guide on [readthedocs.org](https://readthedocs.org/projects/authzforce-ce-fiware/versions/) (select the version matching the Docker image tag, then **AuthzForce - Installation and Administration Guide**) provides you a better approach for using it in a production environment. This installation guide also gives instructions to install from .deb package (instead of Docker), which is the recommended way for Ubuntu hosts.
 
-Create a container using `authzforce/server` image by doing (replace the first *8080* after *-p* with whatever network port you want to use on the host to access the AuthzForce Server, e.g. 80; and *release-8.0.0* with the current Docker image tag that you are using):
+Create a container using `authzforce/server` image by doing (replace the first *8080* after *-p* with whatever network port you want to use on the host to access the AuthzForce Server, e.g. 80; and *release-8.0.1* with the current Docker image tag that you are using):
 
 ```
-docker run -d -p 8080:8080 --name <container-name> fiware/authzforce-ce-server:release-8.0.0
+docker run -d -p 8080:8080 --name <container-name> fiware/authzforce-ce-server:release-8.0.1
 ```
 
 As stands in the AuthZForce Installation and administration guide on [readthedocs.org](https://readthedocs.org/projects/authzforce-ce-fiware/versions/) (select the version matching the Docker image tag, then **AuthzForce - Installation and Administration Guide**) you can:


### PR DESCRIPTION
The docker image  *release-8.0.0* is currently no available according to DockerHub.
<img width="1430" alt="screen shot 2019-01-01 at 18 45 06" src="https://user-images.githubusercontent.com/6523614/50571755-a05b5700-0df5-11e9-8af7-756bec8e0524.png">

So, I updated it for ease of use.